### PR TITLE
Add overlay renderer tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -vv

--- a/src/overlay_renderer.py
+++ b/src/overlay_renderer.py
@@ -9,7 +9,8 @@ def draw_overlays(frame, obj, label="Object", color=(0, 255, 255)):
     left, top, right, bottom = obj["box"]
     cv2.rectangle(frame, (left, top), (right, bottom), color, 2)
 
-    text = f"{label}: {obj.get('id', 'Unknown')} ({obj.get('confidence', 0):.2f})"
+    identifier = obj.get("id") or obj.get("text") or obj.get("type") or "Unknown"
+    text = f"{label}: {identifier} ({obj.get('confidence', 0):.2f})"
     (text_width, text_height), _ = cv2.getTextSize(text, cv2.FONT_HERSHEY_SIMPLEX, 0.5, 1)
 
     cv2.rectangle(frame, (left, top - text_height - 10), (left + text_width, top), color, -1)

--- a/tests/test_overlay_renderer.py
+++ b/tests/test_overlay_renderer.py
@@ -1,0 +1,25 @@
+import numpy as np
+import cv2
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+from overlay_renderer import draw_overlays
+
+def test_plate_text_rendered(monkeypatch):
+    frame = np.zeros((20, 20, 3), dtype=np.uint8)
+    plate = {'box': (0, 0, 10, 10), 'text': 'ABC123', 'confidence': 0.9}
+    captured = {}
+
+    def fake_putText(img, text, org, fontFace, fontScale, color, thickness, lineType):
+        captured['text'] = text
+        return img
+
+    # Monkeypatch OpenCV drawing functions to avoid actual rendering requirements
+    monkeypatch.setattr(cv2, 'putText', fake_putText)
+    monkeypatch.setattr(cv2, 'rectangle', lambda *args, **kwargs: None)
+    monkeypatch.setattr(cv2, 'getTextSize', lambda *args, **kwargs: ((1, 1), None))
+
+    draw_overlays(frame, plate, label='Plate')
+
+    assert 'ABC123' in captured.get('text', '')
+    assert 'Unknown' not in captured.get('text', '')


### PR DESCRIPTION
## Summary
- make `draw_overlays` fall back to `text` or `type` values
- add pytest configuration
- test `draw_overlays` recognizes plate text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868454b4d688327bff4ef2f372c947f