### PR TITLE
Update overlay identifier fallback

### DIFF
--- a/src/overlay_renderer.py
+++ b/src/overlay_renderer.py
@@ -9,7 +9,8 @@ def draw_overlays(frame, obj, label="Object", color=(0, 255, 255)):
     left, top, right, bottom = obj["box"]
     cv2.rectangle(frame, (left, top), (right, bottom), color, 2)
 
-    text = f"{label}: {obj.get('id', 'Unknown')} ({obj.get('confidence', 0):.2f})"
+    identifier = obj.get('id', obj.get('text', 'Unknown'))
+    text = f"{label}: {identifier} ({obj.get('confidence', 0):.2f})"
     (text_width, text_height), _ = cv2.getTextSize(text, cv2.FONT_HERSHEY_SIMPLEX, 0.5, 1)
 
     cv2.rectangle(frame, (left, top - text_height - 10), (left + text_width, top), color, -1)


### PR DESCRIPTION
## Summary
- fallback to `text` when `id` is missing in the overlay renderer

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868455022f08327b0f47a1950d482c2