### PR TITLE
Fix incident report header hyphen

### DIFF
--- a/src/incident_reporter.py
+++ b/src/incident_reporter.py
@@ -28,7 +28,7 @@ def generate_summary():
         summary.setdefault(key, []).append(e)
 
     with open(OUTPUT_PATH, "w") as f:
-        f.write(f"INCIDENT REPORT — {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+        f.write(f"INCIDENT REPORT - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
         f.write("-" * 40 + "\n")
 
         for category, entries in summary.items():


### PR DESCRIPTION
## Summary
- adjust incident report header to use a regular hyphen

## Testing
- `python -m py_compile src/incident_reporter.py`
- `python -m py_compile src/*py`

------
https://chatgpt.com/codex/tasks/task_e_6868455136b8832798c1ab9e332e67d9