### PR TITLE
Fix overlay_renderer import path for tests

### DIFF
--- a/tests/test_overlay_renderer.py
+++ b/tests/test_overlay_renderer.py
@@ -1,9 +1,6 @@
 import numpy as np
 import cv2
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
-from overlay_renderer import draw_overlays
+from src.overlay_renderer import draw_overlays
 
 def test_plate_text_rendered(monkeypatch):
     frame = np.zeros((20, 20, 3), dtype=np.uint8)


### PR DESCRIPTION
## Summary
- make `src` a package with an empty `__init__`
- update overlay renderer tests to import using the new package

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf65902cc8327af87b6a2f04bce18